### PR TITLE
obfuscate_model_name behaviour in api.stan

### DIFF
--- a/pystan/api.py
+++ b/pystan/api.py
@@ -312,6 +312,12 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         Argument `refresh` can be used to control how to indicate the progress
         during sampling (i.e. show the progress every \code{refresh} iterations).
         By default, `refresh` is `max(iter/10, 1)`.
+        
+    obfuscate_model_name : boolean, optional
+        `obfuscate_model_name` is only valid if `fit` is None. True by default.
+        If False the model name in the generated C++ code will not be made
+        unique by the insertion of randomly generated characters.
+        Generally it is recommended that this parameter be left as True. 
 
     Examples
     --------
@@ -364,15 +370,16 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         data = {}
     if warmup is None:
         warmup = int(iter // 2)
+    obfuscate_model_name = kwargs.pop("obfuscate_model_name", True)
     if fit is not None:
         m = fit.stanmodel
     else:
         m = StanModel(file=file, model_name=model_name, model_code=model_code,
                       boost_lib=boost_lib, eigen_lib=eigen_lib,
-                      verbose=verbose)
+                      obfuscate_model_name=obfuscate_model_name, verbose=verbose)
     # check that arguments in kwargs are valid
     valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "enable_random_init",
-                  "refresh", "control", "obfuscate_model_name"}
+                  "refresh", "control"}
     for arg in kwargs:
         if arg not in valid_args:
             raise ValueError("Parameter `{}` is not recognized.".format(arg))


### PR DESCRIPTION
#### Summary:

`pystan.api.stan` the `obfuscate_model_name` is in `valid_args` and is directed to `m.sampling`. Correct behavior is to remove parameter from `kwargs` and redirect parameter to `StanModel`. Added description of the `obfuscate_model_name` to section Other parameters in `pystan.api.stan` docstring.

If `obfuscate_model_name` is in kwargs and set to False the new model name is still obfuscated. If `obfuscate_model_name` parameter is in kwargs with either True or False  a ValueError is raised in `pystan.model`/`sampling`.

"...pystan/model.py", line 703, in sampling
   raise ValueError("Parameter `{}` is not recognized.".format(arg))
ValueError: Parameter `obfuscate_model_name` is not recognized.

#### Intended Effect:

Enable to choose whether to obfuscate new model name or not from `pystan.api.stan`.

#### How to Verify:

Call the `pystan.api.stan` function with `obfuscate_model_name=False´ with `fit=None` to check the name of the created model and following this check the error type raised in `pystan.model`/`sampling`.

#### Side Effects:

None

#### Documentation:

Added description of the `obfuscate_model_name` to section Other parameters in `pystan.api.stan` docstring.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

Pop 'obfuscate_model_name' argument from 'kwargs' in `pystan.api.stan` function. Redirect it to model creation with StanModel instead of model sampling with m.sampling. Removed from the 'valid_args' set and description added to Other parameters section.